### PR TITLE
Add ticket.counter.line model and calendar summary for ticket.daily.c…

### DIFF
--- a/custom_addons/tour_minimal_odoo17/models/ticket_daily_counter.py
+++ b/custom_addons/tour_minimal_odoo17/models/ticket_daily_counter.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, api
 
 class TicketDailyCounter(models.Model):
     _name = 'ticket.daily.counter'
@@ -9,3 +9,24 @@ class TicketDailyCounter(models.Model):
     foreigner_qty = fields.Integer(string="Tickets Extranjeros", default=0)
     sale_order_ids = fields.Many2many('sale.order', string="Órdenes de Venta")
     partner_id = fields.Many2one('res.partner', string="Cliente")
+    ticket_line_ids = fields.One2many('ticket.counter.line', 'counter_id', string="Detalle de Tickets")
+    name = fields.Char(string='Resumen', compute='_compute_name', store=True)
+
+    @api.depends('national_qty', 'foreigner_qty')
+    def _compute_name(self):
+        for rec in self:
+            rec.name = f"Nac: {rec.national_qty} - Ext: {rec.foreigner_qty}"
+
+
+class TicketCounterLine(models.Model):
+    _name = 'ticket.counter.line'
+    _description = 'Detalle de tickets por día y tipo'
+
+    counter_id = fields.Many2one('ticket.daily.counter', ondelete='cascade')
+    sale_order_id = fields.Many2one('sale.order', string='Orden de Venta')
+    partner_id = fields.Many2one(related='sale_order_id.partner_id', store=True)
+    ticket_type = fields.Selection([
+        ('nac', 'Nacional'),
+        ('ext', 'Extranjero')
+    ], string="Tipo de Ticket")
+    qty = fields.Integer(string='Cantidad de Tickets')

--- a/custom_addons/tour_minimal_odoo17/security/ir.model.access.csv
+++ b/custom_addons/tour_minimal_odoo17/security/ir.model.access.csv
@@ -11,3 +11,4 @@ access_tour_type_user,Tour Type User,model_tour_type,sales_team.group_sale_sales
 access_ticket_daily_counter_user,ticket.daily.counter.user,model_ticket_daily_counter,,1,1,1,1
 access_participant_move_wizard,tour.participant.move.wizard,model_tour_participant_move_wizard,,1,1,1,0
 access_tour_flight_user,tour.flight.user,tour_minimal_odoo17.model_tour_flight,,1,1,1,0
+access_ticket_counter_line,ticket.counter.line,model_ticket_counter_line,,1,1,1,1

--- a/custom_addons/tour_minimal_odoo17/views/ticket_daily_counter_views.xml
+++ b/custom_addons/tour_minimal_odoo17/views/ticket_daily_counter_views.xml
@@ -4,6 +4,7 @@
         <field name="model">ticket.daily.counter</field>
         <field name="arch" type="xml">
             <calendar string="Tickets por Día" date_start="date">
+                <field name="name"/>
                 <field name="national_qty"/>
                 <field name="foreigner_qty"/>
             </calendar>
@@ -18,6 +19,7 @@
                 <field name="national_qty"/>
                 <field name="foreigner_qty"/>
                 <field name="partner_id"/>
+                <field name="sale_order_ids" widget="many2many_tags"/>
             </tree>
         </field>
     </record>
@@ -39,6 +41,33 @@
             </kanban>
         </field>
     </record>
+    <record id="view_ticket_daily_counter_form" model="ir.ui.view">
+        <field name="name">ticket.daily.counter.form</field>
+        <field name="model">ticket.daily.counter</field>
+        <field name="arch" type="xml">
+            <form string="Contador Diario de Tickets">
+                <sheet>
+                    <group>
+                        <field name="date"/>
+                        <field name="national_qty"/>
+                        <field name="foreigner_qty"/>
+                        <field name="partner_id"/>
+                    </group>
+                    <group string="Detalle de Tickets por Orden y Tipo">
+                        <field name="ticket_line_ids">
+                            <tree editable="bottom">
+                                <field name="sale_order_id"/>
+                                <field name="partner_id"/>
+                                <field name="ticket_type"/>
+                                <field name="qty"/>
+                            </tree>
+                        </field>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
 
 
     <record id="action_ticket_daily_counter" model="ir.actions.act_window">

--- a/custom_addons/tour_minimal_odoo17/views/tour_minimal_views.xml
+++ b/custom_addons/tour_minimal_odoo17/views/tour_minimal_views.xml
@@ -117,7 +117,7 @@
                 date_start="date_start"
                 date_stop="date_end"
                 color="guide_id"
-                mode="week">
+                mode="month">
                 <field name="name"/>
                 <field name="guide_id"/>
                 <field name="vehicle_id"/>


### PR DESCRIPTION
“Compare & pull request” desde feature/ticket-counter-summary hacia master

Este PR agrega:
- El modelo ticket.counter.line para visualizar resumen detallado por orden y tipo de ticket
- Campo calculado name en ticket.daily.counter para mostrar resumen en calendario
- Ajustes en las vistas tree, calendar y form